### PR TITLE
ADD : GET user data & PUT user password

### DIFF
--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -106,4 +106,33 @@ router.post('/register', function(req, res, next) {
 	
 });
 
+
+/**
+ * 비밀번호 변경
+ * PUT /api/users/password
+ */
+router.put('/password', function(req, res, next) {
+	const user_id = req.body.user_id;
+	const user_prev_pw = req.body.user_prev_pw;
+	const user_want_pw = req.body.user_want_pw;
+		
+	User.findOne({ user_id: user_id, user_pw: user_prev_pw })
+		.then((result) => {
+			if (result)
+				return User.updateOne({ user_id: user_id , user_pw: user_prev_pw }, { user_pw: user_want_pw });
+			return { success:false, message:`아이디 혹은 비밀번호가 틀렸습니다.` };
+		})
+		.then((result) => {
+			if (result.ok)
+				res.json(200, { success:true, message:`${user_id}의 비밀번호가 변경되었습니다.` });
+			else
+				res.json(400, result);
+		})
+		.catch((err) => {
+			console.error(err);
+			next(err);
+		});
+});
+
+
 module.exports = router;

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -22,12 +22,33 @@ router.post('/checkuser', function (req, res) {
 		});
 });
 
+
+/**
+ * 유저정보
+ * GET /api/users
+ */
+router.get('/', function(req, res, next) {
+	const user_id = req.body.user_id || req.params.user_id;
+	
+	User.findOne({ user_id: user_id }, { user_pw: false })
+		.then((result) => {
+			if (result)
+				res.json(200, { success:true, data:result, message:`${user_id} 의 정보` });
+			else
+				res.json(404, { success:false, message:`${user_id}는 없는 유저입니다.` });
+		})
+		.catch((err) => {
+			console.error(err);
+			next(err);
+		})
+});
+
+
 /**
  * 로그인
  * POST /api/users/login
  */
 router.post('/login', function(req, res, next) {
-	console.log('login in');
 	const user = new User({
 		user_id: req.body.user.id,
 		user_pw: req.body.user.password


### PR DESCRIPTION
### 추가사항
- 유저 기본 정보 불러오기 (28bb8cb)
- 유저 비밀번호 변경하기 (0350cbe)

### 사용시
#### 유저 기본 정보 불러오기
```
GET /api/users
```
- `user_id` 값을 body 혹은 query 로 보냅니다.


#### 유저 비밀번호 변경하기
```
PUT /api/users/password
```
- `user_id` 값을 body로 보냅니다.
- `user_prev_pw` 값을 body로 보냅니다.   (현재 비밀번호)
- `user_want_pw ` 값을 body로 보냅니다.  (변경할 비밀번호)


### 주의사항
유저 비밀번호 변경시 아이디 혹은 비밀번호 틀릴때 400 코드로 전송됩니다.
[#4](https://github.com/osamhack2020/Cloud_BlurPencil_GonNyong4/pull/4#issuecomment-707669127) 에서 의논된 방식으로 이를 해결 하기로 했습니다.