### PR TITLE
ADD : Delete user & Forgot password(temp)

### DIFF
--- a/client/src/components/SelectPage.vue
+++ b/client/src/components/SelectPage.vue
@@ -91,6 +91,7 @@
 			this.userdata = response.data.data.user_id+'님<br>환영합니다.'
 		}).catch((err) =>{
 			this.userdata = '로그인이 <br>필요합니다.';
+			console.error(err);
 		})
 	}
   }

--- a/server/app.js
+++ b/server/app.js
@@ -9,6 +9,7 @@ var index = require('./routes/index');
 var upload = require('./routes/upload');
 var users = require('./routes/users');
 var uploadpage = require('./routes/uploadpage');
+var cors = require('cors')
 
 var connectMongoDB = require('./schemas');
 
@@ -20,6 +21,7 @@ app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
 // app.set('views', __dirname + '/views');
 
+app.use(cors())
 
 // uncomment after placing your favicon in /public
 //app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -446,6 +446,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -10,6 +10,7 @@
     "body-parser": "~1.18.2",
     "connect-history-api-fallback": "^1.6.0",
     "cookie-parser": "~1.4.3",
+    "cors": "^2.8.5",
     "debug": "~2.6.9",
     "ejs": "~2.5.7",
     "express": "~4.15.5",

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -134,5 +134,24 @@ router.put('/password', function(req, res, next) {
 		});
 });
 
+/**
+ * 회원 탈퇴
+ * DELETE /api/users
+ */
+router.delete('/', function(req, res, next) {
+	const user_id = req.body.id, 
+		  user_pw = req.body.password;
+	console.log('dd ' , user_id);
+	
+	User.deleteOne({ user_id: user_id, user_pw: user_pw })
+		.then((result) => {
+			console.log(result);
+			res.json(200, { success:true, message:`${user_id} : 회원탈퇴`});
+		})
+		.catch((err) => {
+			console.error(err);
+			next(err);
+		})
+});
 
 module.exports = router;

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -88,6 +88,7 @@ router.post('/login', function(req, res, next) {
 router.post('/register', function(req, res, next) {
 	const user = new User({
 		user_id: req.body.user.id,
+		user_email: req.body.user.email,
 		user_pw: req.body.user.password
 	});
 	
@@ -109,9 +110,9 @@ router.post('/register', function(req, res, next) {
 
 /**
  * 비밀번호 변경
- * PUT /api/users/password
+ * PATCH /api/users/password
  */
-router.put('/password', function(req, res, next) {
+router.patch('/password', function(req, res, next) {
 	const user_id = req.body.user_id;
 	const user_prev_pw = req.body.user_prev_pw;
 	const user_want_pw = req.body.user_want_pw;
@@ -123,7 +124,30 @@ router.put('/password', function(req, res, next) {
 			return { success:false, message:`아이디 혹은 비밀번호가 틀렸습니다.` };
 		})
 		.then((result) => {
-			if (result.ok)
+			if (result.ok && result.nModified)
+				res.json(200, { success:true, message:`${user_id}의 비밀번호가 변경되었습니다.` });
+			else
+				res.json(400, result);
+		})
+		.catch((err) => {
+			console.error(err);
+			next(err);
+		});
+});
+
+/**
+ * 비밀번호 분실시
+ * POST /api/users/password
+ * TODO : 차후 이메일 인증 기능을 넣게 되면 이메일 인증코드를 받고나서 가능하도록 변경해야함.
+ */
+router.post('/password', function(req, res, next) {
+	const user_id = req.body.user_id;
+	const user_email = req.body.user_email;
+	const user_want_pw = req.body.user_want_pw;
+	
+	User.updateOne({ user_id: user_id, user_email: user_email }, { user_pw: user_want_pw })
+		.then((result) => {
+			if (result.ok && result.nModified)
 				res.json(200, { success:true, message:`${user_id}의 비밀번호가 변경되었습니다.` });
 			else
 				res.json(400, result);

--- a/server/schemas/user.js
+++ b/server/schemas/user.js
@@ -8,6 +8,11 @@ const userSchema = new Schema({
 		required: true,
 		unique: true
 	},
+	user_email: {
+		type: String,
+		required: true,
+		unique: true
+	},
 	// 비밀번호
 	user_pw: {
 		type: String,


### PR DESCRIPTION
## 추가사항
- 회원탈퇴 (4af506a)
- 비밀번호 분실시 변경(임시) (86d32f8)
- 클라측 ESLINT 오류 (af07ced)  [이전 PR](https://github.com/osamhack2020/Cloud_BlurPencil_GonNyong4/pull/9#discussion_r506052852)

### 회원탈퇴
```
DELETE /api/users
```
`id`와 `password` 값을 body로 넘겨주어야 합니다.

### 비밀번호 분실 변경
```
POST /api/users/password
```
`id`와 `password`, `email` 을 body로 넘겨주어야 합니다. 
**email 스키마를 이번 커밋에 추가 했기 때문에** 기존 데이터들을 email 값이 없어 인증이 안됩니다.
email 값을 넣어준 회원가입을 통해서만 가능합니다.

> 이제 POST /api/users/register (회원가입) 에서도 email 값을 넘겨주어야 합니다.

> 기존 비밀번호 변경시 사용한 PUT /api/users/password 가 PATCH /api/users/password 로 변경되었습니다.
>> 기존 **비밀번호 변경**과 **비밀번호 분실 변경**은 다른 API 입니다.

차후 이메일 인증 기능을 넣게 되면 이메일 인증코드를 받고나서 가능하도록 변경됩니다.

## 머지조건
기존 비밀번호 변경시 사용한 API 호출 방식이 바뀌었습니다.
@BaeSungJun  님이 본 글을 확인후 우측 Assignees 에 프로필 추가해 주시면 머지하겠습니다.
