### PR TITLE
FIX: fixed bug in /blur API and its example client

### DIFF
--- a/logo_detection/app.py
+++ b/logo_detection/app.py
@@ -11,6 +11,7 @@ import config
 import cv2
 import numpy as np
 import os
+import json
 
 app = Flask(__name__)
 CORS(app)
@@ -33,7 +34,17 @@ def about():
 @app.route('/blur', methods=['POST'])
 def blur(context=None):
     if context is None:
-        boxes = request.json['boxes']
+        print('request dump')
+        print(request)
+        boxes_json = request.form.get('boxes', '[[]]')
+        if boxes_json == '[[]]':
+            print('Emtpy box!')
+        bj = json.loads(boxes_json)
+        boxes = list()
+        for a, b, c, d in bj:
+            boxes.append([float(a),float(b),float(c),float(d)])
+        print(boxes)
+        print('{0}x{1}'.format(len(boxes), len(boxes[0])))
         img = utils.extract_as_jpeg(request)
     else:
         boxes = context['boxes']

--- a/logo_detection/test_clients/test_blur.html
+++ b/logo_detection/test_clients/test_blur.html
@@ -1,14 +1,23 @@
-<form action="https://osam2020-4gb-uokiv.run.goorm.io/predict?visualize=blur" method="POST" enctype='multipart/form-data'>
-  <div class="form-group">
-      <label>사진 업로드</label>
-      <div class="input-group">
-          <span class="input-group-btn">
-              <span class="btn btn-default btn-file">
-                  <input type="file" id="imgInp" name="file">
-              </span>
-          </span>
-      </div>
-      <img id='img-upload' style="margin-top: 10px;"/>
-  </div>
-  <button type="submit" class="btn btn-primary">Submit</button>
+<form id="formElem">
+    <!-- Example image from https://github.com/seungpyo/Cloud_BlurPencil_GonNyong4/blob/logo_detection/logo_detection/test_imgs/subway2.png -->
+  <input type="text" name="boxes" value="[[203.2543100629534,280.38138457707,291.056124823434,307.2524530547006],[448.17743028913225,277.0742453847613,521.2885529654367,307.9938622883388],[359.41433225359236,182.85775065422058,432.0913778032575,309.1329656328474]]">
+  Picture: <input type="file" name="file" accept="image/*">
+  <input type="submit">
+<img id="result"/>
 </form>
+
+<script>
+  formElem.onsubmit = async (e) => {
+    e.preventDefault();
+	image = document.getElementById("result");
+    fetch('https://osam2020-4gb-uokiv.run.goorm.io/blur', {
+      method: 'POST',
+      body: new FormData(formElem)
+    }).then(function(response) {
+	    return response.blob();
+	}).then(function(blob) {
+		const objURL = URL.createObjectURL(blob);
+		image.src = objURL;
+	});
+  };
+</script>


### PR DESCRIPTION
# /blur API 버그 수정하였습니다.
프로젝트의 logo_detection/test_clients/test_blur.html 의 예제를 참고하셔서 formdata를 보내주시면 됩니다.
image와 box좌표를 나타내는 2d json array를 formdata에 첨부하셔서 POST 하시면 됩니다.
리턴값은 blur처리가 완료된 image blob입니다.